### PR TITLE
Adapt to coq/coq#14819

### DIFF
--- a/compatibility/Coq__8_15__Compat.v
+++ b/compatibility/Coq__8_15__Compat.v
@@ -19,10 +19,10 @@ Require Coq.ZArith.BinIntDef Coq.PArith.BinPosDef Coq.NArith.BinNatDef.
 Require Coq.Reals.Rdefinitions.
 Require Coq.Numbers.Cyclic.Int63.Int63.
 Require Coq.Numbers.Cyclic.Int31.Int31.
-Numeral Notation BinNums.Z BinIntDef.Z.of_num_int BinIntDef.Z.to_num_int : Z_scope.
-Numeral Notation BinNums.positive BinPosDef.Pos.of_num_int BinPosDef.Pos.to_num_int : positive_scope.
-Numeral Notation BinNums.N BinNatDef.N.of_num_int BinNatDef.N.to_num_int : N_scope.
-Numeral Notation Int31.int31 Int31.phi_inv_nonneg Int31.phi : int31_scope.
+Number Notation BinNums.Z BinIntDef.Z.of_num_int BinIntDef.Z.to_num_int : Z_scope.
+Number Notation BinNums.positive BinPosDef.Pos.of_num_int BinPosDef.Pos.to_num_int : positive_scope.
+Number Notation BinNums.N BinNatDef.N.of_num_int BinNatDef.N.to_num_int : N_scope.
+Number Notation Int31.int31 Int31.phi_inv_nonneg Int31.phi : int31_scope.
 
 Local Set Warnings "-deprecated".
 Global Set Firstorder Solver auto with *.

--- a/compatibility/Coq__master__Compat.v
+++ b/compatibility/Coq__master__Compat.v
@@ -19,10 +19,10 @@ Require Coq.ZArith.BinIntDef Coq.PArith.BinPosDef Coq.NArith.BinNatDef.
 Require Coq.Reals.Rdefinitions.
 Require Coq.Numbers.Cyclic.Int63.Int63.
 Require Coq.Numbers.Cyclic.Int31.Int31.
-Numeral Notation BinNums.Z BinIntDef.Z.of_num_int BinIntDef.Z.to_num_int : Z_scope.
-Numeral Notation BinNums.positive BinPosDef.Pos.of_num_int BinPosDef.Pos.to_num_int : positive_scope.
-Numeral Notation BinNums.N BinNatDef.N.of_num_int BinNatDef.N.to_num_int : N_scope.
-Numeral Notation Int31.int31 Int31.phi_inv_nonneg Int31.phi : int31_scope.
+Number Notation BinNums.Z BinIntDef.Z.of_num_int BinIntDef.Z.to_num_int : Z_scope.
+Number Notation BinNums.positive BinPosDef.Pos.of_num_int BinPosDef.Pos.to_num_int : positive_scope.
+Number Notation BinNums.N BinNatDef.N.of_num_int BinNatDef.N.to_num_int : N_scope.
+Number Notation Int31.int31 Int31.phi_inv_nonneg Int31.phi : int31_scope.
 
 Local Set Warnings "-deprecated".
 Global Set Firstorder Solver auto with *.


### PR DESCRIPTION
`Numeral Notation` was deprecated in 8.13 and should be removed in 8.15.