### PR TITLE
Compatibility for Coq 8.16

### DIFF
--- a/compatibility/Coq__8_16__Compat.v
+++ b/compatibility/Coq__8_16__Compat.v
@@ -1,0 +1,63 @@
+(** See https://coq.inria.fr/bugs/show_bug.cgi?id=4319 for updates *)
+
+(** Compatibility file for making Coq act similar to Coq v8.8 *)
+Local Set Warnings "-deprecated".
+
+Require Export Coq.Compat.Coq814.
+
+Unset Private Polymorphic Universes.
+
+(** Unsafe flag, can hide inconsistencies. *)
+Global Unset Template Check.
+
+(** In Coq 8.9, prim token notations follow [Import] rather than
+    [Require].  So we make all of the relevant notations accessible in
+    compatibility mode. *)
+Require Coq.Strings.Ascii Coq.Strings.String.
+Export String.StringSyntax Ascii.AsciiSyntax.
+Require Coq.ZArith.BinIntDef Coq.PArith.BinPosDef Coq.NArith.BinNatDef.
+Require Coq.Reals.Rdefinitions.
+Require Coq.Numbers.Cyclic.Int63.Int63.
+Require Coq.Numbers.Cyclic.Int31.Int31.
+Number Notation BinNums.Z BinIntDef.Z.of_num_int BinIntDef.Z.to_num_int : Z_scope.
+Number Notation BinNums.positive BinPosDef.Pos.of_num_int BinPosDef.Pos.to_num_int : positive_scope.
+Number Notation BinNums.N BinNatDef.N.of_num_int BinNatDef.N.to_num_int : N_scope.
+Number Notation Int31.int31 Int31.phi_inv_nonneg Int31.phi : int31_scope.
+
+Local Set Warnings "-deprecated".
+Global Set Firstorder Solver auto with *.
+Global Set Instance Generalized Output.
+
+Require Coq.micromega.Lia.
+Module Export Coq.
+  Module Export omega.
+    Module Export Omega.
+      #[deprecated(since="8.12", note="The omega tactic was removed in v8.14.  You're now relying on the lia tactic.")]
+      Ltac omega := Lia.lia.
+    End Omega.
+  End omega.
+End Coq.
+
+(** [set (x := y)] is about 50x slower than it needs to be in Coq 8.4,
+    but is about 4x faster than the alternatives in 8.5.  See
+    https://coq.inria.fr/bugs/show_bug.cgi?id=3280 (comment 13) for
+    more details. *)
+Ltac fast_set' x y := set (x := y).
+Ltac fast_set'_in x y H := set (x := y) in H.
+Tactic Notation "fast_set" "(" ident(x) ":=" constr(y) ")" := fast_set' x y.
+Tactic Notation "fast_set" "(" ident(x) ":=" constr(y) ")" "in" hyp(H) := fast_set'_in x y H.
+
+(** Add Coq 8.4+8.5 notations, so that we don't accidentally make use of Coq 8.4-only notations *)
+Require Coq.Lists.List.
+Require Coq.Vectors.Vector.
+Module Export LocalListNotations.
+Notation " [ ] " := nil (format "[ ]") : list_scope.
+Notation " [ x ; .. ; y ] " := (cons x .. (cons y nil) ..) : list_scope.
+Notation " [ x ; y ; .. ; z ] " := (cons x (cons y .. (cons z nil) ..)) : list_scope.
+End LocalListNotations.
+Module Export LocalVectorNotations.
+Notation " [ ] " := (Vector.nil _) (format "[ ]") : vector_scope.
+Notation " [ x ; .. ; y ] " := (Vector.cons _ x _ .. (Vector.cons _ y _ (Vector.nil _)) ..) : vector_scope.
+Notation " [ x ; y ; .. ; z ] " := (Vector.cons _ x _ (Vector.cons _ y _ .. (Vector.cons _ z _ (Vector.nil _)) ..)) : vector_scope.
+End LocalVectorNotations.
+Require Export Coq.funind.FunInd.

--- a/compatibility/Coq__8_16__Compat.v.in
+++ b/compatibility/Coq__8_16__Compat.v.in
@@ -1,0 +1,1 @@
+(** See https://coq.inria.fr/bugs/show_bug.cgi?id=4319 for updates *)

--- a/compatibility/generate-compat-files.sh
+++ b/compatibility/generate-compat-files.sh
@@ -19,21 +19,21 @@ function append_text() {
     done
 }
 
-ALL_VERSIONS="8_4 8_5beta1 8_5beta2 8_5beta3 8_5rc1 8_5 8_5pl1 8_6beta1 8_6 8_7 8_8 8_9 8_10 8_11 8_12 8_13 8_14 8_15 trunk master"
-VECTOR_LIST_VERSIONS="8_4 8_5beta1 8_5beta2 8_5beta3 8_5rc1 8_5 8_5pl1 8_6beta1 8_6 8_7 8_8 8_9 8_10 8_11 8_12 8_13 8_14 8_15 trunk master"
+ALL_VERSIONS="8_4 8_5beta1 8_5beta2 8_5beta3 8_5rc1 8_5 8_5pl1 8_6beta1 8_6 8_7 8_8 8_9 8_10 8_11 8_12 8_13 8_14 8_15 8_16 trunk master"
+VECTOR_LIST_VERSIONS="8_4 8_5beta1 8_5beta2 8_5beta3 8_5rc1 8_5 8_5pl1 8_6beta1 8_6 8_7 8_8 8_9 8_10 8_11 8_12 8_13 8_14 8_15 8_16 trunk master"
 NPEANO_VERSIONS="8_5beta1 8_5beta2 8_5beta3 8_5rc1 8_5 8_5pl1"
 FMAPFACTS_VERSIONS="8_5beta1 8_5beta2 8_5beta3 8_5rc1 8_5 8_5pl1"
 COQ_MODULE_VERSIONS="8_5beta1 8_5beta2 8_5beta3 8_5rc1 8_5 8_5pl1"
-FAST_SET_AS_SET_VERSIONS="8_5beta1 8_5beta2 8_5beta3 8_5rc1 8_5 8_5pl1 8_6beta1 8_6 8_7 8_8 8_9 8_10 8_11 8_12 8_13 8_14 8_15 trunk master"
+FAST_SET_AS_SET_VERSIONS="8_5beta1 8_5beta2 8_5beta3 8_5rc1 8_5 8_5pl1 8_6beta1 8_6 8_7 8_8 8_9 8_10 8_11 8_12 8_13 8_14 8_15 8_16 trunk master"
 RELATION_ARGUMENTS_VERSIONS="8_5beta1 8_5beta2 8_5beta3 8_5rc1 8_5"
 RAPPLY_SHELVE_VERSIONS="8_5beta1 8_5beta2 8_5beta3"
 MISC_BETA1_VERSIONS="8_5beta1 8_5beta2"
 INT_VERSIONS="8_5beta2"
-FUNIND_VERSIONS="8_7 8_8 8_9 8_10 8_11 8_12 8_13 8_14 8_15 trunk master"
+FUNIND_VERSIONS="8_7 8_8 8_9 8_10 8_11 8_12 8_13 8_14 8_15 8_16 trunk master"
 GRAB_88_VERSIONS="8_9 8_10 8_11"
 GRAB_88v811_VERSIONS="8_12"
 GRAB_88v813_VERSIONS="8_13"
-GRAB_88v814_VERSIONS="8_14 8_15 master"
+GRAB_88v814_VERSIONS="8_14 8_15 8_16 master"
 
 for v in $ALL_VERSIONS; do
     cp -f "Coq__${v}__Compat.v.in" "Coq__${v}__Compat.v"


### PR DESCRIPTION
Generated with
```bash
export V=16; cp compatibility/Coq__master__Compat.v.in compatibility/Coq__8_${V}__Compat.v.in && sed "s/8_$(($V-1))/8_$(($V-1)) 8_$V/g" -i compatibility/generate-compat-files.sh && ./compatibility/generate-compat-files.sh && git add compatibility/Coq__8_${V}__Compat.v{,.in}
```