### PR TITLE
Fix version parsing.

### DIFF
--- a/compatibility/Makefile.coq.compat_84_85-early
+++ b/compatibility/Makefile.coq.compat_84_85-early
@@ -39,7 +39,7 @@ ifeq ($(_COQPROJECT_NAME),_CoqProject)
 _COQPROJECT_NAME = $(_COQPROJECT_IN_NAME)
 endif
 
-COQ_VERSION_PREFIX = The .* Proof Assistant, version
+COQ_VERSION_PREFIX = The .*, version
 COQ_VERSION := $(firstword $(shell $(COQBIN)coqc --version 2>/dev/null | sed 's/$(COQ_VERSION_PREFIX)//'))
 COQ_VERSION_MAJOR_MINOR:=$(strip $(shell echo '$(COQ_VERSION)' | grep -o '^[0-9]\+\.[0-9]\+'))
 COQ_VERSION_MAJOR:=$(firstword $(subst ., ,$(COQ_VERSION_MAJOR_MINOR)))


### PR DESCRIPTION
This time for good, hopefully. It turns out that coq/coq#20027 still had an incorrect phrasing of the output of the --version command.